### PR TITLE
[FIX] Increase field limits for csv files

### DIFF
--- a/dodoo_dbhandler/initializer.py
+++ b/dodoo_dbhandler/initializer.py
@@ -22,6 +22,7 @@
 #
 
 import contextlib
+import csv
 import hashlib
 import logging
 import os
@@ -417,6 +418,10 @@ def init(
     checksum of modules provided with the -m option, including their
     dependencies and corresponding auto_install modules.
     """
+
+    # See commit 68f14c68709bbb50cb7fb66d288955e1d769c5ff in odoo/odoo
+    csv.field_size_limit(500 * 1024 * 1024)
+
     module_names = [m.strip() for m in modules.split(",")]
     if not cache:
         if new_database:


### PR DESCRIPTION
As comment shows: https://github.com/odoo/odoo/blob/68f14c68709bbb50cb7fb66d288955e1d769c5ff/openerp/cli/server.py#L146-L149

Without this patch, you won't be able to deploy demo data for module https://github.com/it-projects-llc/website-addons/tree/cb274ee5f1a843beaf026113b2577256b8c41562/website_multi_company_demo
using command
```
docker-compose up dodoo -- init --new-database db --demo -m website_multi_company_demo
```
because while reading some `demo/website.csv` it will throw exception
```
Error: field larger than field limit (131072)
```
(assuming that we are using odooup, and added `git@github.com:it-projects-llc/website-addons.git` as additional repository)